### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 		
 		<dependency>
 			<groupId>io.github.hakky54</groupId>
-			<artifactId>sslcontext-kickstart-for-pem</artifactId>
-			<version>8.3.7</version>
+			<artifactId>ayza-for-pem</artifactId>
+			<version>10.0.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience